### PR TITLE
Add Sevulet suite (aeroshell)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,11 @@
             aeroglasspane = self.callPackage ./pkgs/external/software/aeroglasspane.nix {};
             plymouthvista = self.callPackage ./pkgs/external/system/plymouthvista.nix {};
             linver = self.callPackage ./pkgs/external/software/linver.nix {};
+
+            sevulet-explorer = self.callPackage ./pkgs/external/software/sevulet/7sExplorer.nix {};
+            sevulet-notepad = self.callPackage ./pkgs/external/software/sevulet/7sNotepad.nix {};
+            sevulet-photoview = self.callPackage ./pkgs/external/software/sevulet/7sPhotoView.nix {};
+            sevulet-stickies = self.callPackage ./pkgs/external/software/sevulet/7sStickies.nix {};
           })
         );
       };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,8 @@ in
     sddm.enable = lib.mkEnableOption "the SDDM theme";
   };
 
+  options.programs.sevulet.enable = lib.mkEnableOption "the Sevulet software suite";
+
   config = lib.mkIf cfg.enable {
     assertions = [{
       assertion = cfg.plymouth.enable -> cfg.fonts.enable;
@@ -44,7 +46,7 @@ in
 
       pkgs.kdePackages.qtstyleplugin-kvantum
       libplasma libtaskmanager libshowdesktop
-    ]);
+    ]) ++ lib.optionals config.programs.sevulet.enable [ atpkgs.sevulet-explorer atpkgs.sevulet-notepad atpkgs.sevulet-photoview atpkgs.sevulet-stickies ];
 
     boot.plymouth = lib.mkIf cfg.plymouth.enable {
       theme = "PlymouthVista";

--- a/pkgs/external/software/sevulet/7sExplorer.nix
+++ b/pkgs/external/software/sevulet/7sExplorer.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  qt6,
+  kdePackages
+}:
+stdenv.mkDerivation {
+  pname = "7sExplorer";
+  version = "19191afb";
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "snailatte";
+    repo = "7s-explorer";
+    rev = "19191afb680f7a276c7f2c9058d4304e8cc4848c";
+    sha256 = "sha256-1hIHZuBBcoAovRoQXeQ53VCEaUEXxQRYxKK9Pm+L2HE=";
+  };
+
+  buildInputs = [ qt6.qtbase qt6.qtmultimedia kdePackages.kwindowsystem kdePackages.kservice kdePackages.kio kdePackages.kcoreaddons ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook qt6.qmake ];
+
+  # Snaillatte hardcoded all the paths and it breaks compilation on nixos. This fixes it
+  qmakeFlags = [
+    "explorer.pro"
+    "INCLUDEPATH+=${kdePackages.kwindowsystem.dev}/include/KF6/KWindowSystem"
+    "INCLUDEPATH+=${kdePackages.kservice.dev}/include/KF6/KService"
+    "INCLUDEPATH+=${kdePackages.kio.dev}/include/KF6/KIO"
+    "INCLUDEPATH+=${kdePackages.kio.dev}/include/KF6/KIOCore"
+    "INCLUDEPATH+=${kdePackages.kcoreaddons.dev}/include/KF6/KCoreAddons"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+
+    cp -R ./installation/hicolor $out/share/icons
+    sed "s|~/.local|$out|g" ./installation/explorer.desktop > $out/share/applications/explorer.desktop
+    cp -f ./explorer $out/bin
+    runHook postInstall
+  '';
+}

--- a/pkgs/external/software/sevulet/7sNotepad.nix
+++ b/pkgs/external/software/sevulet/7sNotepad.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  qt6
+}:
+stdenv.mkDerivation {
+  pname = "7sNotepad";
+  version = "7733e2f9";
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "snailatte";
+    repo = "7s-notepad";
+    rev = "7733e2f9fa50d84120136ddfe4bbf2902fe0e938";
+    sha256 = "sha256-dl2GdeYfDklzU3qUd/xfAuGABabLJMSFPnLEstbH6gc=";
+  };
+
+  buildInputs = [ qt6.qtbase ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook qt6.qmake ];
+
+  qmakeFlags = [
+    "notepad.pro"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+    
+    cp -R ./installation/hicolor $out/share/icons
+    sed "s|~/.local|$out|g" ./installation/notepad.desktop > $out/share/applications/notepad.desktop
+    cp -f ./notepad $out/bin
+    runHook postInstall
+  '';
+}

--- a/pkgs/external/software/sevulet/7sPhotoView.nix
+++ b/pkgs/external/software/sevulet/7sPhotoView.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  qt6,
+  kdePackages
+}:
+stdenv.mkDerivation {
+  pname = "7sPhotoView";
+  version = "bf1082eb";
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "snailatte";
+    repo = "7s-photoview";
+    rev = "bf1082ebce479633541d40ea94de416163f846f1";
+    sha256 = "sha256-kwXAe/bka8mkZ11b7EEWZC7dz7zart6rmzLyDrJ1zuE=";
+  };
+
+  buildInputs = [ qt6.qtbase kdePackages.kwindowsystem ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook qt6.qmake ];
+
+  qmakeFlags = [
+    "photoview.pro"
+    "INCLUDEPATH+=${kdePackages.kwindowsystem.dev}/include/KF6/KWindowSystem"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+
+    cp -R ./installation/hicolor $out/share/icons
+    sed "s|~/.local|$out|g" ./installation/photoview.desktop > $out/share/applications/photoview.desktop
+    cp -f ./photoview $out/bin
+    runHook postInstall
+  '';
+}

--- a/pkgs/external/software/sevulet/7sStickies.nix
+++ b/pkgs/external/software/sevulet/7sStickies.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  qt6
+}:
+stdenv.mkDerivation {
+  pname = "7sStickies";
+  version = "f1ed6d0f";
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "snailatte";
+    repo = "7s-stickies";
+    rev = "f1ed6d0f5329f5bbaed7c22f20ae22532bd82402";
+    sha256 = "sha256-iqGwZ13GtqEvzMi4xKUABpNmJb7aCU72YOgCXKIpbxU=";
+  };
+
+  buildInputs = [ qt6.qtbase ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook qt6.qmake ];
+
+  qmakeFlags = [
+    "stickies.pro"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+
+    cp -R ./installation/hicolor $out/share/icons
+    sed "s|~/.local|$out|g" ./installation/stickies.desktop > $out/share/applications/stickies.desktop
+    cp -f ./stickies $out/bin
+    runHook postInstall
+  '';
+}

--- a/vms/aerothemeplasma.nix
+++ b/vms/aerothemeplasma.nix
@@ -26,4 +26,5 @@
     plymouth.enable = true;
     sddm.enable = true;
   };
+  programs.sevulet.enable = true;
 }

--- a/vms/aerothemeplasma.nix
+++ b/vms/aerothemeplasma.nix
@@ -26,5 +26,6 @@
     plymouth.enable = true;
     sddm.enable = true;
   };
+  
   programs.sevulet.enable = true;
 }


### PR DESCRIPTION
This PR adds support for the following members of the Sevulet software suite:

- 7sExplorer
- 7sNotepad
- 7sPhotoView
- 7sStickies

Closes #3 .

Enable with:
```
    programs.sevulet.enable = true;
```