### PR TITLE
uac-polkit-agent: init at 2026-02-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ aerothemeplasma = {
   fonts.enable = true;
   plymouth.enable = true;
   sddm.enable = true;
+  polkit.enable = true;
 };
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,13 @@
               rev = "c7e74773709e9d03a04e15d143867f4a89d849f4";
               hash = "sha256-qzgTgPB7bbI25fjmWlqSHFFDpFJKcqBpqOCWLyUANyk=";
             };
+            aeroshell-uac-repo = pkgs.fetchFromGitLab {
+              domain = "gitgud.io";
+              owner = "aeroshell";
+              repo = "uac-polkit-agent";
+              rev = "f284a37b688c0f57984fd1604c1134c2629a8028";
+              hash = "sha256-E+UV0cRZcrQNtFkDQXfQPxtayKkamzLybElLFLNc26o=";
+            };
             
             libplasma = self.callPackage ./pkgs/aeroshell/hacks/libplasma.nix {};
             plasma-workspace = self.callPackage ./pkgs/aeroshell/hacks/plasma-workspace.nix {};
@@ -118,6 +125,7 @@
 
             login-session = self.callPackage ./pkgs/aerothemeplasma/system/login-session.nix {};
             sddm-theme-mod = self.callPackage ./pkgs/aerothemeplasma/system/sddm-theme-mod.nix {};
+            uac-polkit-agent = self.callPackage ./pkgs/aerothemeplasma/system/uac-polkit-agent.nix {};
 
             segoe-ui = self.callPackage ./pkgs/external/fonts/segoe-ui.nix {};
             lucida-console = self.callPackage ./pkgs/external/fonts/lucida-console.nix {};

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -57,6 +57,10 @@ in
       themePackages = [ atpkgs.plymouthvista ];
     };
 
+    systemd.packages = with atpkgs; [
+      uac-polkit-agent
+    ];
+
     services.displayManager.sddm = lib.mkIf cfg.sddm.enable {
       theme = "${atpkgs.sddm-theme-mod}/share/sddm/themes/sddm-theme-mod";
       extraPackages = [ pkgs.kdePackages.kitemmodels ];

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -57,7 +57,7 @@ in
       themePackages = [ atpkgs.plymouthvista ];
     };
 
-    systemd.packages = with atpkgs; [
+    systemd.packages = with atpkgs; lib.optionals cfg.plasma.enable [
       uac-polkit-agent
     ];
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -10,6 +10,7 @@ in
     plasma.enable = lib.mkEnableOption "the AeroThemePlasma theme packages";
     fonts.enable = lib.mkEnableOption "the Segoe UI and Lucida Console fonts";
     plymouth.enable = lib.mkEnableOption "the PlymouthVista theme";
+    polkit.enable = lib.mkEnableOption "the Polkit agent replacement";
     sddm.enable = lib.mkEnableOption "the SDDM theme";
   };
 
@@ -57,7 +58,7 @@ in
       themePackages = [ atpkgs.plymouthvista ];
     };
 
-    systemd.packages = with atpkgs; lib.optionals cfg.plasma.enable [
+    systemd.packages = with atpkgs; lib.optionals cfg.polkit.enable [
       uac-polkit-agent
     ];
 

--- a/pkgs/aerothemeplasma/system/uac-polkit-agent.nix
+++ b/pkgs/aerothemeplasma/system/uac-polkit-agent.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  pkgs,
+  aeroshell-uac-repo,
+  cmake,
+  kdePackages,
+}:
+stdenv.mkDerivation {
+  pname = "aero-uac-polkit-agent";
+  src = aeroshell-uac-repo;
+  version = "2026-02-25";
+
+  buildInputs = with kdePackages; [
+    qtbase
+    qtdeclarative
+    kcoreaddons
+    ki18n
+    kwindowsystem
+    knotifications
+    kdbusaddons
+    kcrash
+    kconfig
+    polkit-qt-1
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  # From: https://github.com/DuCanhGH/snowflakes/blob/766fd883850f1d8592386e3b422fd4ff8778e6b8/modules/nixos/aero/kde/uac-polkit-agent.nix#L4
+  postFixup = ''
+    rm -rf $out/share/systemd/user/uac-polkit-agent.service
+    substituteInPlace $out/etc/systemd/user/plasma-polkit-agent.service.d/uac-polkit-agent.conf \
+      --replace-fail "/bin/sh" "${pkgs.bash}/bin/bash" \
+      --replace-fail "$out/libexec/polkit-kde-authentication-agent-1" "${pkgs.kdePackages.polkit-kde-agent-1}/libexec/polkit-kde-authentication-agent-1"
+  '';
+}

--- a/pkgs/aerothemeplasma/system/uac-polkit-agent.nix
+++ b/pkgs/aerothemeplasma/system/uac-polkit-agent.nix
@@ -6,7 +6,7 @@
   kdePackages,
 }:
 stdenv.mkDerivation {
-  pname = "aero-uac-polkit-agent";
+  pname = "aeroshell-uac-polkit-agent";
   src = aeroshell-uac-repo;
   version = "2026-02-25";
 

--- a/vms/aerothemeplasma.nix
+++ b/vms/aerothemeplasma.nix
@@ -26,6 +26,7 @@
     fonts.enable = true;
     plymouth.enable = true;
     sddm.enable = true;
+    polkit.enable = true;
   };
   programs = {
     sevulet.enable = true;


### PR DESCRIPTION
This makes the password prompt match the Aero theme better.

this could potentially be behind a `uac.enable` config or similar to make it optional

<img width="1149" height="760" alt="image" src="https://github.com/user-attachments/assets/922218c9-0224-4d9e-93d1-a9396a318740" />
