### PR TITLE
notifications: add knotifyconfig to buildInputs

### DIFF
--- a/pkgs/aerothemeplasma/plasmoids/notifications.nix
+++ b/pkgs/aerothemeplasma/plasmoids/notifications.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
   preConfigure = "cd plasma/plasmoids/src/notifications_src";
   buildInputs = with kdePackages; [
     plasma-workspace
+    knotifyconfig
   ];
   nativeBuildInputs = [ cmake pkg-config kdePackages.wrapQtAppsHook ];
 }


### PR DESCRIPTION
The notifications plasmoid's `CMakeLists.txt` requires `KF6 NotifyConfig`, which lives in `kdePackages.knotifyconfig`. Without it in `buildInputs`, configure fails:

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find KF6 (missing: NotifyConfig) (found version \"6.25.0\")
```

Adding `knotifyconfig` resolves the build. Tested by `nixos-rebuild switch` against `nixpkgs/nixos-unstable` (KF6 6.25.0).